### PR TITLE
Add XRT Edge support

### DIFF
--- a/k8s-fpga-device-plugin/edge-vitis-test-pod.yaml
+++ b/k8s-fpga-device-plugin/edge-vitis-test-pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vitis-test-pod
+spec:
+  containers:
+  - name: vitis-test-pod
+    image: paroque28/wrl_vitis_ai_resnet:latest
+    imagePullPolicy: IfNotPresent
+    resources:
+      limits:
+        xilinx.com/fpga-ZynqMP-ZCU102: 1
+    command: ["resnet50", "/opt/Vitis-AI/img/greyfox-672194.JPEG"]

--- a/k8s-fpga-device-plugin/fpga-device-plugin.yml
+++ b/k8s-fpga-device-plugin/fpga-device-plugin.yml
@@ -38,7 +38,7 @@ spec:
       - image: xilinxatg/xilinx_k8s_fpga_plugin:latest
         name: xilinx-fpga-device-plugin
         securityContext:
-          allowPrivilegeEscalation: false
+          privileged: true
           capabilities:
             drop: ["ALL"]
         volumeMounts:


### PR DESCRIPTION
Tested with: Xilinx ZynqMP ZCU102, XRT 2019.2.
```bash
# kubectl apply -f fpga-device-plugin.yml 
daemonset.apps/fpga-device-plugin-daemonset configured
# kubectl get pods --namespace=kube-system
NAME                                      READY   STATUS             RESTARTS   AGE
fpga-device-plugin-daemonset-cpdwd        1/1     Running            0          13s


# kubectl logs fpga-device-plugin-daemonset-cpdwd --namespace=kube-system
time="2020-04-30T01:25:56Z" level=info msg="Starting FS watcher."
time="2020-04-30T01:25:56Z" level=info msg="Starting OS watcher."
time="2020-04-30T01:25:56Z" level=info msg="Starting to serve on /var/lib/kubelet/device-plugins/ZynqMP-ZCU102-fpga.sock"
2020/04/30 01:25:56 grpc: Server.Serve failed to create ServerTransport:  connection error: desc = "transport: write unix /var/lib/kubelet/device-plugins/ZynqMP-ZCU102-fpga.sock->@: write: broken pipe"
time="2020-04-30T01:25:56Z" level=info msg="Registered device plugin with Kubelet xilinx.com/fpga-ZynqMP-ZCU102"
time="2020-04-30T01:25:56Z" level=info msg="Sending 1 device(s) [&Device{ID:1,Health:Healthy,}] to kubelet"
time="2020-04-30T01:26:05Z" level=info msg="Receiving request 1"


# kubectl describe node zcu102-zynqmp

Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                       Requests   Limits
  --------                       --------   ------
  cpu                            100m (2%)  0 (0%)
  memory                         70Mi (1%)  170Mi (4%)
  ephemeral-storage              0 (0%)     0 (0%)
  xilinx.com/fpga-ZynqMP-ZCU102  1          1
```
Test:
```
#  kubectl apply -f edge-vitis-test-pod.yaml
pod/vitis-test-pod created
# kubectl get pods

NAME             READY   STATUS      RESTARTS   AGE
vitis-test-pod   0/1     Completed   0          8s

# kubectl logs vitis-test-pod
Input Image size: 640 x 480 x 3
Input featuremap: 224 x 224
[TimeTest]dpuSetInputImage2             6914      us
[TimeTest]dpuRunTask                    52837     us
[TimeTest]dpuGetOutputTensorInHWCFP32   41        us
[TimeTest]CPUCalcSoftmax                86        us
TimeTest[0]  = 0.512263  name = grey fox, gray fox, Urocyon cinereoargenteus
[TimeTest]TopK                          108       us
```

This output proves the functioning of all the components.

Read all notes in the commit messages.

Build made with: https://github.com/Xilinx/FPGA_as_a_Service/pull/13