### PR TITLE
Add Arista as a shell vendor for FPGA as a service

### DIFF
--- a/k8s-fpga-device-plugin/fpga.go
+++ b/k8s-fpga-device-plugin/fpga.go
@@ -44,6 +44,7 @@ const (
 	XilinxVendorID = "0x10ee"
 	ADVANTECH_ID   = "0x13fe"
 	AWS_ID         = "0x1d0f"
+	AristaVendorID = "0x3475"
 )
 
 type Pairs struct {
@@ -153,6 +154,7 @@ func GetDevices() ([]Device, error) {
 			return nil, err
 		}
 		if strings.EqualFold(vendorID, XilinxVendorID) != true &&
+			strings.EqualFold(vendorID, AristaVendorID) != true &&
 			strings.EqualFold(vendorID, AWS_ID) != true &&
 			strings.EqualFold(vendorID, ADVANTECH_ID) != true {
 			continue

--- a/k8s-fpga-device-plugin/quickstart.md
+++ b/k8s-fpga-device-plugin/quickstart.md
@@ -119,11 +119,11 @@ spec:
   containers:
   - name: mypod
     image: xilinxatg/fpga-verify:latest
-  resources:
-    limits:
-      xilinx.com/fpga-xilinx_u200_xdma_201820_1-1535712995: 1
-  command: ["/bin/sh"]
-  args: ["-c", "while true; do echo hello; sleep 5;done;"]
+    resources:
+      limits:
+        xilinx.com/fpga-xilinx_u200_xdma_201830_1-1542252769: 1
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo hello; sleep 10;done"]
 ```
 
 Deploy the pod now


### PR DESCRIPTION
This changeset adds support for Arista shells to the FPGA as a service k8s plugin, and adds a fixup for the Readme, which has incorrect tabbing for the example YAML. 